### PR TITLE
feat: add ability to save enabled in cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Example config
 ```lua
 require("transparent").setup({
   enable = true, -- boolean: enable transparent
+  save_state = true, -- boolean: allow saving transparent state
   extra_groups = { -- table/string: additional groups that should be cleared
     -- In particular, when you set it to 'all', that means all available groups
 

--- a/lua/transparent.lua
+++ b/lua/transparent.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local config = {
   enable = false,
+  save_state = true, -- allow save state to file
   groups = {
     "Normal",
     "NormalNC",
@@ -30,6 +31,32 @@ local config = {
   exclude = {},
   ignore_linked_group = true,
 }
+
+local cache_path = vim.fn.stdpath("data") .. "/nvim-transparent"
+
+local open_cache_file = function(mode)
+  --- 438(10) == 666(8) [owner/group/others can read/write]
+  local flags = 438
+  local fd, err = vim.loop.fs_open(cache_path, mode, flags)
+  if err then
+    vim.api.nvim_notify(("Error opening cache file:\n\n%s"):format(err), vim.log.levels.ERROR, {})
+  end
+  return fd
+end
+
+local read_cache_file = function()
+  local fd = open_cache_file("r")
+  if not fd then
+    return nil
+  end
+
+  local stat = assert(vim.loop.fs_fstat(fd))
+  local data = assert(vim.loop.fs_read(fd, stat.size, -1))
+  assert(vim.loop.fs_close(fd))
+
+  local enabled, _ = data:gsub("[\n\r]", "")
+  return enabled == "true"
+end
 
 local clear_group_bg = function(group, highlights)
   if not (group or highlights) then
@@ -116,10 +143,27 @@ function M.toggle_transparent(option)
   else
     vim.cmd("doautocmd ColorScheme")
   end
+
+  -- Write to cache file
+  local fd = open_cache_file("w")
+  if not fd then
+    vim.api.nvim_notify("Could not write cache file!\n\n", vim.log.levels.ERROR, {})
+    return
+  end
+
+  assert(vim.loop.fs_write(fd, ("%s\n"):format(vim.g.transparent_enabled), -1))
+  assert(vim.loop.fs_close(fd))
 end
 
 function M.setup(user_config)
   config = vim.tbl_extend("force", config, user_config)
+
+  -- Read cache file if enabled
+  if config.enable and config.save_state then
+    local save_state = read_cache_file()
+    vim.g.transparent_enabled = save_state
+  end
+
   if vim.g.transparent_enabled == nil then
     vim.g.transparent_enabled = config.enable
   end


### PR DESCRIPTION
As I often found myself tweaking my neovim config just to turn transparent on/off, I found that would be nice to keep the toggle state in a cache file.
I just finished adding the same feature in my plugin [nvim-listchars](https://github.com/fraso-dev/nvim-listchars) (which is highly inspired by nvim-transparent) and I thought that this kind of plugins should have the same behaviour.